### PR TITLE
Fix login refactoring to hide file upload

### DIFF
--- a/web/app/src/App.vue
+++ b/web/app/src/App.vue
@@ -100,7 +100,7 @@
 
       <!-- TODO(prashanth@): issues/16: refactor into HomeView.vue -->
       <router-view
-        v-if="$route.name === 'Login'"
+        v-else-if="$route.name === 'Login'"
       ></router-view>
 
       <!-- Only show main content when logged in and not on dashboard -->


### PR DESCRIPTION
Previously because of a v-if mess up the file upload would persist into the dashboard view blocking the search bar. This commit un-reverts the login changes, and adds a v-if-else to avoid this issue.

This commit is built atop a "Revert "Revert "Add login support""" commit, so the only change is the `v-if-else` added to the login page (https://github.com/bprashanth/fomo/pull/19)